### PR TITLE
Merge refactor/vm/remove-operation-type

### DIFF
--- a/VM/Code/Converter.cs
+++ b/VM/Code/Converter.cs
@@ -20,7 +20,7 @@ public class Converter(Token[] _tokens)
         {
             if (Lexer.InstructionDictionary.TryGetValue(CurrentToken.Type.ToString(), out var tokenType) && Enum.TryParse<Instruction>(tokenType.ToString(), out var instruction))
             {
-                currentBytecodePart = new Operation(instruction, [], typeof(byte[]));
+                currentBytecodePart = new Operation(instruction, []);
                 Advance();
                 byteCode.Add(currentBytecodePart);
             }

--- a/VM/Intructions/Operation.cs
+++ b/VM/Intructions/Operation.cs
@@ -6,19 +6,15 @@ public record Operation : IByteCodePart
 {
     public Instruction Instruction { get; set; }
     public byte[] Operand { get; set; }
-    public Type Type { get; set; }
 
-    public Operation(Instruction instruction, byte[] operand, Type type)
+    public Operation(Instruction instruction, byte[] operand)
     {
         Instruction = instruction;
         Operand = operand;
-        Type = type;
     }
-    public Operation(Instruction Instruction, Type Type) : this(Instruction, [], Type) { }
-    public Operation(Instruction Instruction) : this(Instruction, [], typeof(byte)) { }
 
     public override string ToString()
     {
-        return $"{Instruction} {string.Join(", ", Operand)} {Type}";
+        return $"{Instruction} {string.Join(", ", Operand)}";
     }
 }

--- a/VMTests/Code/ConverterTest.cs
+++ b/VMTests/Code/ConverterTest.cs
@@ -19,7 +19,7 @@ public class ConverterTests
         var code = converter.ByteCode;
 
         IByteCodePart[] expected = [
-            new Operation(Instruction.SUM, typeof(byte[]))
+            new Operation(Instruction.SUM, [])
         ];
 
         Assert.That(code, Is.EqualTo(expected));
@@ -40,7 +40,7 @@ public class ConverterTests
         var code = converter.ByteCode;
 
         IByteCodePart[] expected = [
-            new Operation(Instruction.PUSH, [10, 0, 0, 0, 0, 0, 0, 0], typeof(byte[]))
+            new Operation(Instruction.PUSH, [10, 0, 0, 0, 0, 0, 0, 0])
         ];
 
 

--- a/VMTests/VirtualMachine/VMTest.cs
+++ b/VMTests/VirtualMachine/VMTest.cs
@@ -16,7 +16,7 @@ public class VMTest
     {
         var vm = new IonicVM();
         List<IByteCodePart> code = [
-            new Operation(Instruction.PUSH, [1, 2, 3, 4], typeof(byte[]))
+            new Operation(Instruction.PUSH, [1, 2, 3, 4])
         ];
         vm.LoadCode(code);
         vm.Run();
@@ -29,7 +29,7 @@ public class VMTest
     {
         var vm = new IonicVM();
         List<IByteCodePart> code = [
-            new Operation(Instruction.PUSH, [10], typeof(byte))
+            new Operation(Instruction.PUSH, [10])
         ];
         vm.LoadCode(code);
         vm.Run();
@@ -42,8 +42,8 @@ public class VMTest
     {
         var vm = new IonicVM();
         List<IByteCodePart> code = [
-            new Operation(Instruction.PUSH, [1, 2, 3, 4], typeof(byte[])),
-            new Operation(Instruction.SUM, typeof(byte))
+            new Operation(Instruction.PUSH, [1, 2, 3, 4]),
+            new Operation(Instruction.SUM, [])
         ];
 
         vm.LoadCode(code);
@@ -57,7 +57,7 @@ public class VMTest
     {
         var vm = new IonicVM();
         List<IByteCodePart> code = [
-            new Operation(Instruction.AS, BitConverter.GetBytes(1), typeof(byte[]))
+            new Operation(Instruction.AS, BitConverter.GetBytes(1))
         ];
 
         vm.LoadCode(code);
@@ -70,8 +70,8 @@ public class VMTest
     {
         var vm = new IonicVM();
         List<IByteCodePart> code = [
-            new Operation(Instruction.PUSH, BitConverter.GetBytes(4), typeof(byte[])),
-            new Operation(Instruction.STORE, BitConverter.GetBytes(2), typeof(byte[]))
+            new Operation(Instruction.PUSH, BitConverter.GetBytes(4)),
+            new Operation(Instruction.STORE, BitConverter.GetBytes(2))
         ];
 
         vm.LoadCode(code);
@@ -96,9 +96,9 @@ public class VMTest
         int index = 0;
 
         List<IByteCodePart> code = [
-            new Operation(Instruction.PUSH, BitConverter.GetBytes(number), typeof(byte[])),
-            new Operation(Instruction.AS, BitConverter.GetBytes(type), typeof(byte[])),
-            new Operation(Instruction.STORE, BitConverter.GetBytes(index), typeof(byte[]))
+            new Operation(Instruction.PUSH, BitConverter.GetBytes(number)),
+            new Operation(Instruction.AS, BitConverter.GetBytes(type)),
+            new Operation(Instruction.STORE, BitConverter.GetBytes(index))
         ];
 
         vm.LoadCode(code);


### PR DESCRIPTION
- Removed Type from Operation because its useless
- Removed typeof(byte[])